### PR TITLE
Implements required content types

### DIFF
--- a/api/category/config/routes.json
+++ b/api/category/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/categories",
+      "handler": "category.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/categories/count",
+      "handler": "category.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/categories/:id",
+      "handler": "category.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/categories",
+      "handler": "category.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/categories/:id",
+      "handler": "category.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/categories/:id",
+      "handler": "category.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/category/controllers/category.js
+++ b/api/category/controllers/category.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/category/models/category.js
+++ b/api/category/models/category.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/category/models/category.settings.json
+++ b/api/category/models/category.settings.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "categories",
+  "info": {
+    "name": "Category"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "cover_photo": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images"
+      ],
+      "plugin": "upload",
+      "required": true
+    }
+  }
+}

--- a/api/category/services/category.js
+++ b/api/category/services/category.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/api/course/config/routes.json
+++ b/api/course/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/courses",
+      "handler": "course.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/courses/count",
+      "handler": "course.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/courses/:id",
+      "handler": "course.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/courses",
+      "handler": "course.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/courses/:id",
+      "handler": "course.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/courses/:id",
+      "handler": "course.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/course/controllers/course.js
+++ b/api/course/controllers/course.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/course/models/course.js
+++ b/api/course/models/course.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/course/models/course.settings.json
+++ b/api/course/models/course.settings.json
@@ -1,8 +1,8 @@
 {
   "kind": "collectionType",
-  "collectionName": "articles",
+  "collectionName": "courses",
   "info": {
-    "name": "Article",
+    "name": "Course",
     "description": ""
   },
   "options": {
@@ -11,19 +11,24 @@
     "draftAndPublish": true
   },
   "attributes": {
-    "cover_photo": {
-      "model": "file",
-      "via": "related",
-      "allowedTypes": [
-        "images"
-      ],
-      "plugin": "upload",
-      "required": true
-    },
-    "localized_articles": {
+    "questions": {
       "type": "component",
       "repeatable": true,
-      "component": "article.localized-article"
+      "component": "course.question"
+    },
+    "slides": {
+      "type": "component",
+      "repeatable": true,
+      "component": "course.slide"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "language": {
+      "model": "language"
     },
     "publisher": {
       "model": "publisher"

--- a/api/course/services/course.js
+++ b/api/course/services/course.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/api/home/config/routes.json
+++ b/api/home/config/routes.json
@@ -1,0 +1,28 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/home",
+      "handler": "home.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/home",
+      "handler": "home.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/home",
+      "handler": "home.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/home/controllers/home.js
+++ b/api/home/controllers/home.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/home/models/home.js
+++ b/api/home/models/home.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/home/models/home.settings.json
+++ b/api/home/models/home.settings.json
@@ -1,0 +1,22 @@
+{
+  "kind": "singleType",
+  "collectionName": "homes",
+  "info": {
+    "name": "Home"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "header": {
+      "type": "string",
+      "required": true
+    },
+    "introduction": {
+      "type": "richtext",
+      "required": true
+    }
+  }
+}

--- a/api/home/services/home.js
+++ b/api/home/services/home.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/api/language/config/routes.json
+++ b/api/language/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/languages",
+      "handler": "language.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/languages/count",
+      "handler": "language.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/languages/:id",
+      "handler": "language.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/languages",
+      "handler": "language.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/languages/:id",
+      "handler": "language.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/languages/:id",
+      "handler": "language.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/language/controllers/language.js
+++ b/api/language/controllers/language.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/language/models/language.js
+++ b/api/language/models/language.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/language/models/language.settings.json
+++ b/api/language/models/language.settings.json
@@ -1,0 +1,26 @@
+{
+  "kind": "collectionType",
+  "collectionName": "languages",
+  "info": {
+    "name": "Language",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "Slug": {
+      "type": "uid",
+      "targetField": "name",
+      "maxLength": 2,
+      "minLength": 2,
+      "required": true
+    }
+  }
+}

--- a/api/language/services/language.js
+++ b/api/language/services/language.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/api/publisher/config/routes.json
+++ b/api/publisher/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/publishers",
+      "handler": "publisher.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/publishers/count",
+      "handler": "publisher.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/publishers/:id",
+      "handler": "publisher.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/publishers",
+      "handler": "publisher.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/publishers/:id",
+      "handler": "publisher.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/publishers/:id",
+      "handler": "publisher.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/publisher/controllers/publisher.js
+++ b/api/publisher/controllers/publisher.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/publisher/models/publisher.js
+++ b/api/publisher/models/publisher.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/publisher/models/publisher.settings.json
+++ b/api/publisher/models/publisher.settings.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "publishers",
+  "info": {
+    "name": "Publisher"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "avatar": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images"
+      ],
+      "plugin": "upload",
+      "required": true
+    }
+  }
+}

--- a/api/publisher/services/publisher.js
+++ b/api/publisher/services/publisher.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/components/article/document.json
+++ b/components/article/document.json
@@ -1,0 +1,23 @@
+{
+  "collectionName": "components_article_documents",
+  "info": {
+    "name": "document",
+    "icon": "file-pdf"
+  },
+  "options": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "document": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "files"
+      ],
+      "plugin": "upload",
+      "required": true
+    }
+  }
+}

--- a/components/article/localized-article.json
+++ b/components/article/localized-article.json
@@ -1,0 +1,32 @@
+{
+  "collectionName": "components_article_localized_articles",
+  "info": {
+    "name": "localized_article",
+    "icon": "envelope-open-text",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "resources": {
+      "type": "component",
+      "repeatable": true,
+      "component": "article.source"
+    },
+    "documents": {
+      "type": "component",
+      "repeatable": true,
+      "component": "article.document"
+    },
+    "language": {
+      "model": "language"
+    }
+  }
+}

--- a/components/article/source.json
+++ b/components/article/source.json
@@ -1,0 +1,27 @@
+{
+  "collectionName": "components_article_sources",
+  "info": {
+    "name": "resource",
+    "icon": "link",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "url": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "source_name": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/components/course/alternative.json
+++ b/components/course/alternative.json
@@ -1,0 +1,29 @@
+{
+  "collectionName": "components_course_alternatives",
+  "info": {
+    "name": "Alternative",
+    "icon": "check",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "image": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images"
+      ],
+      "plugin": "upload",
+      "required": false
+    },
+    "correct": {
+      "type": "boolean",
+      "required": true,
+      "default": false
+    }
+  }
+}

--- a/components/course/localized-course.json
+++ b/components/course/localized-course.json
@@ -1,0 +1,27 @@
+{
+  "collectionName": "components_course_localized_courses",
+  "info": {
+    "name": "Localized_course",
+    "icon": "calendar-check",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "slides": {
+      "type": "component",
+      "repeatable": true,
+      "component": "course.slide"
+    },
+    "language": {
+      "model": "language"
+    }
+  }
+}

--- a/components/course/question.json
+++ b/components/course/question.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_course_questions",
+  "info": {
+    "name": "Question",
+    "icon": "gamepad",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "question": {
+      "type": "string",
+      "required": true
+    },
+    "alternatives": {
+      "type": "component",
+      "repeatable": true,
+      "component": "course.alternative",
+      "required": true
+    },
+    "clarification": {
+      "type": "richtext",
+      "required": true
+    }
+  }
+}

--- a/components/course/slide.json
+++ b/components/course/slide.json
@@ -1,0 +1,29 @@
+{
+  "collectionName": "components_course_slides",
+  "info": {
+    "name": "Slide",
+    "icon": "info-circle",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "image": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images",
+        "videos"
+      ],
+      "plugin": "upload",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
## Jira

Fixes BL-11, BL-34, BL-76, BL-124. 

## Explanation 


Adds the following **content-types:**
- Article
- Course
- Publisher
- Language


Adds the following **single types**: 
- Home


Adds the following **components**: 
- Article
  - Localized_article
  - Document
  - Resource
- Course
  - Localized_course
  - Alternative
  - Question
  - Slide


## Details

Strapi is currently undergoing development of a native localization/internationalization system that should be used if it is finished in time (Q1 2021, https://portal.productboard.com/strapi/1-roadmap/c/19-content-internationalization-ce-ee-v3), 

In the meantime we will group all Localized_articles (components) in each Article (content-type). This will not work for courses, as it will require nesting components deeper then what is currently allowed. If does this not change, a "hacky" implementation might be necessary in the future. 

## Unresolved Questions
- If Strapi doesn't implement the new localization system in time, should we make sure that our implementation works in the same way for both articles and courses? This would make the system more convoluted, but might make it easier to train new admins. 
